### PR TITLE
Deploy project with 404 error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,16 @@
 {
-  "builds": [
-    {
-      "src": "**/*",
-      "use": "@vercel/static"
-    }
-  ],
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
   "routes": [
     {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
       "src": "/(.*)",
-      "dest": "/$1"
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
Configure Vercel to correctly build and serve a Vite React application by updating `vercel.json`.

The previous `vercel.json` used `@vercel/static`, which is unsuitable for Vite-built React applications and caused a 404 error for `main.jsx`. This update configures Vercel to correctly run the Vite build process and serve the output, ensuring proper Single Page Application (SPA) routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9297991c-65eb-486f-8346-eab6317ce753">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9297991c-65eb-486f-8346-eab6317ce753">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

