### PR TITLE
Add web2 option for blockchain network selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1039,4 +1039,12 @@ a:hover {
   .game-canvas-container {
     padding: 5px;
   }
+
+  /* Web2 Classic Mode Styles */
+  .web2-mode {
+    color: #2ecc71;
+    font-weight: normal;
+    font-size: 0.8em;
+    opacity: 0.9;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -193,16 +193,22 @@ const App = () => {
                 ← Back to Network Selection
               </button>
             </div>
-            <WalletComponent 
-              selectedNetwork={selectedNetwork} 
-              onDisconnect={handleDisconnect}
-              disableNetworkControls={true}
-            />
+            {/* Only show WalletComponent for blockchain networks, not for web2 */}
+            {selectedNetwork && !selectedNetwork.isWeb2 && (
+              <WalletComponent 
+                selectedNetwork={selectedNetwork} 
+                onDisconnect={handleDisconnect}
+                disableNetworkControls={true}
+              />
+            )}
             <div className="game-layout">
               <div className="game-header">
                 <div className="header-center">
                   <div className="title">
                     Buddy Runner
+                    {selectedNetwork && selectedNetwork.isWeb2 && (
+                      <span className="web2-mode"> - Classic Mode</span>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/GameComponent.jsx
+++ b/src/components/GameComponent.jsx
@@ -111,6 +111,15 @@ const GameComponent = ({ selectedNetwork }) => {
 
   // Get wallet information for display
   const getWalletInfo = () => {
+    // For web2 mode, return special identifier
+    if (selectedNetwork && selectedNetwork.isWeb2) {
+      return {
+        identifier: "CLASSIC PLAYER",
+        address: null,
+        isWeb2: true
+      };
+    }
+    
     if (!authenticated || !user) return null;
     
     const address = getWalletAddress();
@@ -128,10 +137,7 @@ const GameComponent = ({ selectedNetwork }) => {
       };
     }
     
-    return {
-      identifier: 'User',
-      address: null
-    };
+    return null;
   };
 
   // Get wallet address
@@ -141,6 +147,19 @@ const GameComponent = ({ selectedNetwork }) => {
   };
 
   useEffect(() => {
+    // Skip blockchain initialization for web2 mode
+    if (selectedNetwork && selectedNetwork.isWeb2) {
+      setBlockchainStatus({
+        initialized: false,
+        networkName: selectedNetwork.name,
+        contractAvailable: false,
+        pendingTransactions: 0,
+        totalMovements: 0,
+        onChainScore: 0
+      });
+      return;
+    }
+    
     initializeBlockchain();
   }, [authenticated, user, selectedNetwork]);
 

--- a/src/components/NetworkSelection.jsx
+++ b/src/components/NetworkSelection.jsx
@@ -16,6 +16,17 @@ const NetworkSelection = ({ onNetworkSelect, onStartGame }) => {
 
   const networks = [
     { 
+      id: 'web2', 
+      name: 'CLASSIC BROWSER', 
+      emoji: '🌐',
+      description: 'Pure web2 experience',
+      tech: 'No wallet required',
+      color: '#2ecc71',
+      status: 'ONLINE',
+      icon: '🦕',
+      isWeb2: true
+    },
+    { 
       id: 6342, 
       name: 'MEGAETH TESTNET', 
       emoji: '⚡',
@@ -151,6 +162,13 @@ const NetworkSelection = ({ onNetworkSelect, onStartGame }) => {
 
   const handleStartGame = () => {
     if (selectedNetwork) {
+      // If web2 option is selected, skip wallet connection entirely
+      if (selectedNetwork.isWeb2) {
+        onStartGame(selectedNetwork);
+        return;
+      }
+      
+      // For blockchain networks, handle wallet authentication
       if (authenticated && user) {
         // If already authenticated, go directly to game
         onStartGame(selectedNetwork);
@@ -272,12 +290,12 @@ const NetworkSelection = ({ onNetworkSelect, onStartGame }) => {
 
                   <div className="network-specs">
                     <div className="spec-item">
-                      <span className="spec-label">CHAIN ID:</span>
-                      <span className="spec-value">{network.id}</span>
+                      <span className="spec-label">{network.isWeb2 ? 'TYPE:' : 'CHAIN ID:'}</span>
+                      <span className="spec-value">{network.isWeb2 ? 'WEB2' : network.id}</span>
                     </div>
                     <div className="spec-item">
                       <span className="spec-label">NETWORK:</span>
-                      <span className="spec-value">TESTNET</span>
+                      <span className="spec-value">{network.isWeb2 ? 'BROWSER' : 'TESTNET'}</span>
                     </div>
                   </div>
 


### PR DESCRIPTION
Add a 'CLASSIC BROWSER' (web2) option to allow users to play the game without requiring a crypto wallet connection.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f9d00e-398a-41ca-9464-3f2a1a0cee84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18f9d00e-398a-41ca-9464-3f2a1a0cee84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

