### PR TITLE
Fix transaction pool refill logic

### DIFF
--- a/src/hooks/useBlockchainUtils.js
+++ b/src/hooks/useBlockchainUtils.js
@@ -15,7 +15,7 @@ const NETWORK_CONFIGS = {
     contractAddress: '0xb34cac1135c27ec810e7e6880325085783c1a7e0', // Updater contract
     faucetAddress: '0x76b71a17d82232fd29aca475d14ed596c67c4b85',
     chainId: 6342,
-    sendMethod: 'eth_sendRawTransaction', // Переключаемся на стандартный метод, realtime отключен
+    sendMethod: 'realtime_sendRawTransaction', // Возвращаем realtime для мгновенного подтверждения
     connectionTimeouts: {
       initial: 10000, // 10 seconds for initial connection
       retry: 3000,    // 3 seconds for retries (быстрые retry для gaming)

--- a/src/hooks/useBlockchainUtils.js
+++ b/src/hooks/useBlockchainUtils.js
@@ -15,7 +15,7 @@ const NETWORK_CONFIGS = {
     contractAddress: '0xb34cac1135c27ec810e7e6880325085783c1a7e0', // Updater contract
     faucetAddress: '0x76b71a17d82232fd29aca475d14ed596c67c4b85',
     chainId: 6342,
-    sendMethod: 'realtime_sendRawTransaction', // Специальный метод для MegaETH
+    sendMethod: 'eth_sendRawTransaction', // Переключаемся на стандартный метод, realtime отключен
     connectionTimeouts: {
       initial: 10000, // 10 seconds for initial connection
       retry: 3000,    // 3 seconds for retries (быстрые retry для gaming)
@@ -1247,8 +1247,8 @@ export const useBlockchainUtils = () => {
               const nextNonce = manager.pendingNonce;
               
               // РЕШЕНИЕ ПРОБЛЕМЫ: Добавляем больше транзакций для длинных сессий
-              // 3 потребили -> 20+ добавляем для гарантированного опережения
-              const refillSize = Math.max(25, poolConfig.batchSize * 1.5);
+              // Пополняем пул фиксированным размером, избегая чрезмерного расширения
+              const refillSize = poolConfig.batchSize; // без роста объёма пула
               console.log(`🚀 ENHANCED pool: adding ${refillSize} transactions (consumed 3, net growth +${refillSize-3})`);
               console.log(`📊 Pool status before refill: ${pool.transactions.length - pool.currentIndex} remaining`);
               


### PR DESCRIPTION
Fixes pre-signed transaction pool refilling and disables `realtime_sendRawTransaction` for MegaETH to prevent transaction slowdowns and RPC timeouts.

The `realtime_sendRawTransaction` method for MegaETH was causing RPC timeouts and significant transaction delays (up to 6 seconds) when the pre-signed transaction pool was depleted or undergoing a large refill. The previous "aggressive" refill logic calculated a fractional amount (e.g., 52.5 transactions), leading to an overly large signing batch that blocked subsequent refills and forced the system to fall back to slow real-time transactions. This PR switches MegaETH to `eth_sendRawTransaction`, ensures refill batches are always whole numbers, and sets the refill size to `batchSize` to maintain a healthy pool without over-signing or blocking.

---
<a href="https://cursor.com/background-agent?bcId=bc-e40dd208-8daf-477d-9a03-cdff7d3eb6d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e40dd208-8daf-477d-9a03-cdff7d3eb6d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

