### PR TITLE
Fix initial token balance recognition

### DIFF
--- a/src/hooks/useBlockchainUtils.js
+++ b/src/hooks/useBlockchainUtils.js
@@ -1801,19 +1801,17 @@ export const useBlockchainUtils = () => {
       
       console.log('💰 Faucet success:', result);
       
-      // Если faucet возвращает txHash, ждем немного и обновляем баланс
+            // Если faucet возвращает txHash, немедленно обновляем баланс
       if (result.txHash) {
-        console.log('⏳ Waiting for faucet transaction to be processed...');
+        console.log('⏳ Faucet transaction sent, updating balance immediately...');
         
-        // Асинхронно обновляем баланс через 3 секунды
-        setTimeout(async () => {
-          try {
-            await checkBalance(chainId);
-            console.log('✅ Balance updated after faucet transaction');
-          } catch (error) {
-            console.warn('Failed to update balance after faucet:', error);
-          }
-        }, 3000);
+        // НЕМЕДЛЕННО обновляем баланс
+        try {
+          await checkBalance(chainId);
+          console.log('✅ Balance updated immediately after faucet transaction');
+        } catch (error) {
+          console.warn('Failed to update balance after faucet:', error);
+        }
       }
       
       return {
@@ -2416,8 +2414,8 @@ export const useBlockchainUtils = () => {
               } else {
                 console.log('⚠️ Faucet sent to non-embedded wallet:', faucetWallet.address);
               }
-              // Обновляем баланс через 5 секунд
-              setTimeout(() => checkBalance(chainId), 5000);
+              // НЕМЕДЛЕННО обновляем баланс после faucet
+              await checkBalance(chainId);
               // Обновляем nonce после faucet
               return getNextNonce(chainId, faucetWallet.address, true);
             })


### PR DESCRIPTION
Remove balance check delays after faucet calls to ensure immediate balance recognition and prevent page refreshes for new users.

Previously, new users received tokens from the faucet, but the game would attempt to pre-sign transactions with a 0 balance due to 3-second and 5-second delays before the balance was updated. This fix ensures the balance is known *before* the game starts, eliminating the need for a page refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-09caf3fa-b5d0-4030-a45a-874f488a207b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09caf3fa-b5d0-4030-a45a-874f488a207b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

