### PR TITLE
Adjust faucet balance check timing

### DIFF
--- a/src/hooks/useBlockchainUtils.js
+++ b/src/hooks/useBlockchainUtils.js
@@ -1801,19 +1801,14 @@ export const useBlockchainUtils = () => {
       
       console.log('💰 Faucet success:', result);
       
-      // Если faucet возвращает txHash, ждем немного и обновляем баланс
+      // Если faucet возвращает txHash, сразу обновляем баланс
       if (result.txHash) {
-        console.log('⏳ Waiting for faucet transaction to be processed...');
-        
-        // Асинхронно обновляем баланс через 3 секунды
-        setTimeout(async () => {
-          try {
-            await checkBalance(chainId);
-            console.log('✅ Balance updated after faucet transaction');
-          } catch (error) {
-            console.warn('Failed to update balance after faucet:', error);
-          }
-        }, 3000);
+        try {
+          await checkBalance(chainId);
+          console.log('✅ Balance updated immediately after faucet transaction');
+        } catch (error) {
+          console.warn('Failed to update balance immediately after faucet:', error);
+        }
       }
       
       return {
@@ -2409,15 +2404,19 @@ export const useBlockchainUtils = () => {
       
       // НЕБЛОКИРУЮЩИЙ faucet вызов (строго на embedded wallet)
       callFaucet(faucetWallet.address, chainId)
-            .then((result) => {
+            .then(async (result) => {
               console.log('✅ Background faucet completed');
               if (result.isEmbeddedWallet) {
                 console.log('✅ Faucet sent to embedded wallet:', faucetWallet.address);
               } else {
                 console.log('⚠️ Faucet sent to non-embedded wallet:', faucetWallet.address);
               }
-              // Обновляем баланс через 5 секунд
-              setTimeout(() => checkBalance(chainId), 5000);
+              // Немедленно обновляем баланс и дожидаемся результата
+              try {
+                await checkBalance(chainId);
+              } catch (e) {
+                console.warn('Failed to immediately refresh balance after faucet:', e);
+              }
               // Обновляем nonce после faucet
               return getNextNonce(chainId, faucetWallet.address, true);
             })


### PR DESCRIPTION
Update balance immediately after faucet calls to prevent pre-signing with a stale zero balance.

The previous implementation used `setTimeout` to delay `checkBalance` by 3 or 5 seconds after a faucet request. This delay caused the system to pre-sign transactions with an outdated balance (often 0) right after funds were received, leading to incorrect behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-d67af236-fe24-4923-87cd-1fc9a5414607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d67af236-fe24-4923-87cd-1fc9a5414607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

